### PR TITLE
allow multithreaded request serving

### DIFF
--- a/tileserver/__init__.py
+++ b/tileserver/__init__.py
@@ -386,6 +386,6 @@ if __name__ == '__main__':
     tile_server.propagate_errors = True
 
     server_config = config['server']
-    run_simple(server_config['host'], server_config['port'], tile_server,
+    run_simple(server_config['host'], server_config['port'], tile_server, threaded=server_config.get('threaded', False),
                use_debugger=server_config.get('debug', False),
                use_reloader=server_config.get('reload', False))


### PR DESCRIPTION
The server uses a single thread by deafult and tends to choke on multiple simultaneous requests. This change simply exposes werkzeug's http server threaded feature. The config.yaml can contain a threaded: true entry in the server section, and this allows the server to scale in a smoother fashion on multicore machines.
